### PR TITLE
[fix] Allow .5 utility classes from TailwindCSS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ function VitePluginWindicss(options: Options = {}): Plugin[] {
       return
 
     const regQuotedString = /(["'`])((?:\\\1|(?:(?!\1)).)*?)\1/g
-    const regClassCheck = /^[a-z0-9:\-/\\]+[a-z0-9]$/
+    const regClassCheck = /^[a-z\-]+[a-z0-9:\-/\\]*\.?[a-z0-9]$/
 
     debug.detect(id)
     Array.from(code.matchAll(regQuotedString))


### PR DESCRIPTION
### Description 📖 

This pull request enables the dot character (`.`) to be present in a CSS class, such as in `m-0.5`.

It also adds a small performance improvement by ignoring numbers in SVG paths, which were previously being matched. That should reduce the amount of ignored items in memory.

### Background 📜 

At the moment existing Tailwind classes, such as `p-0.5` and `ml-1.5`, are being ignored.

As a result windicss does not generate the corresponding CSS for these classes.