### PR TITLE
Allow headings to be detected, allowing preflight generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ function VitePluginWindicss(options: Options = {}): Plugin[] {
         classesPending.add(i)
       })
 
-    Array.from(code.matchAll(/<([a-z]+)/g))
+    Array.from(code.matchAll(/<([a-z]+[0-9]?)/g))
       .flatMap(([, i]) => i)
       .forEach((i) => {
         if (!tagsAvaliable.has(i))


### PR DESCRIPTION
### Description

This pull request fixes the regex used for tag detection, which was ignoring headings (`h1`, `h2`, ...).

As a result, the preflight styling rules will be appropriately generated.

### Screenshots 📷 

Example preflight rule:

<img width="426" alt="Screen Shot 2021-02-14 at 16 54 50" src="https://user-images.githubusercontent.com/1158253/107887591-e694a700-6ee5-11eb-8c6f-e65ea2e57545.png">
